### PR TITLE
Delete posts and comments backend

### DIFF
--- a/api/controllers/comments.js
+++ b/api/controllers/comments.js
@@ -1,5 +1,6 @@
 const Comment = require("../models/comment");
 const TokenGenerator = require("../lib/token_generator");
+const jwt = require("jsonwebtoken");
 
 const CommentsController = {
   Index: (req, res) => {
@@ -45,6 +46,42 @@ const CommentsController = {
     } catch (err) {
       // Handle any unexpected error
       return res.status(500).json({ error: 'Unexpected error occurred.' });
+    }
+  },
+  Delete: async (req, res) => {
+    try {
+      // Added validation if the request hasn't got the "Authorization" header
+      // you are not able to make a comment
+      if (!req.headers.authorization) {
+        return res.status(401).json({ error: 'Unauthorized. Missing token.' });
+      }
+      // checking if comment exists
+      const comment = await Comment.findById(req.params.id);
+      if (!comment) {
+        return res.status(404).json({ error: 'Comment not found.'});
+      }
+      // To compare id's of users, we need to get access to the id of
+      // of the user who's logged in. This parameter is unavailable 
+      // in the req so we need to extract it from Authorization token.
+      const token = req.headers.authorization.split(' ')[1];
+      // Verify the token to get the payload, including the user_id
+      const decodedToken = jwt.verify(token, process.env.JWT_SECRET);
+      // user_id - who wants to delete comment
+      const user_id = decodedToken.user_id;
+
+      if (comment.user.toString() !== user_id) {
+        return res.status(403).json({ error: 'Forbidden. You Are not allowed to delete this comment.'});
+      }
+      //delete the comment
+      await comment.deleteOne();
+      //return success response
+      const newToken = TokenGenerator.jsonwebtoken(user_id);
+      res
+        .status(200)
+        .json({ message: 'Comment deleted succesfully.', token: newToken });
+    } 
+    catch (err) {
+      return res.status(500).json({ error: 'Unexpected error occured.' });
     }
   },
 };

--- a/api/controllers/comments.js
+++ b/api/controllers/comments.js
@@ -1,19 +1,34 @@
-
 const Comment = require("../models/comment");
 const TokenGenerator = require("../lib/token_generator");
 
 const CommentsController = {
   Index: (req, res) => {
-    Comment.find((err, comments) => {
-      if (err) {
-        throw err;
+    try {
+      // Added validation if the request hasn't got the "Authorization" header
+      // you are not able to get comments
+      if (!req.headers.authorization) {
+        return res.status(401).json({ error: 'Unauthorized. Missing token.' });
       }
-      const token = TokenGenerator.jsonwebtoken(req.user_id)
-      res.status(200).json({ comments: comments, token: token });
-    });
+
+      Comment.find((err, comments) => {
+        if (err) {
+          throw err;
+        }
+        const token = TokenGenerator.jsonwebtoken(req.user_id)
+        res.status(200).json({ comments: comments, token: token });
+      });
+    } catch (err) {
+      // Handle any unexpected error
+      return res.status(500).json({ error: 'Unexpected error occurred.' });
+    }
   },
   Create: (req, res) => {
     try {
+      // Added validation if the request hasn't got the "Authorization" header
+      // you are not able to make a comment
+      if (!req.headers.authorization) {
+        return res.status(401).json({ error: 'Unauthorized. Missing token.' });
+      }
       const comment = new Comment({
         comment: req.body.comment,
         user: req.body.user,

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -90,7 +90,6 @@ const PostsController = {
       await Comment.deleteMany({ post: post._id });
       //delete the post
       await post.deleteOne();
-      console.log("post.deleteOne(): ", post.deleteOne());
       //return success response
       const newToken = TokenGenerator.jsonwebtoken(user_id);
       res

--- a/api/models/comment.js
+++ b/api/models/comment.js
@@ -11,10 +11,9 @@ const CommentSchema = new mongoose.Schema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Post',
         required: true
-      }
-  });
-  
-  const Comment = mongoose.model("Comment", CommentSchema);
-  
-  module.exports = Comment;
-  
+    }
+});
+
+const Comment = mongoose.model("Comment", CommentSchema);
+
+module.exports = Comment;

--- a/api/routes/comments.js
+++ b/api/routes/comments.js
@@ -5,5 +5,6 @@ const CommentsController = require("../controllers/comments");
 
 router.get("/", CommentsController.Index);
 router.post("/", CommentsController.Create);
+router.delete("/:id", CommentsController.Delete);
 
 module.exports = router;

--- a/api/routes/posts.js
+++ b/api/routes/posts.js
@@ -6,5 +6,6 @@ const PostsController = require("../controllers/posts");
 router.get("/", PostsController.Index);
 router.post("/", PostsController.Create);
 router.put("/:id", PostsController.Update);
+router.delete("/:id", PostsController.Delete);
 
 module.exports = router;

--- a/api/spec/controllers/comments.spec.js
+++ b/api/spec/controllers/comments.spec.js
@@ -211,10 +211,6 @@ describe("/comments", () => {
 			await post.save();
 			const comment = new Comment({post: post._id, user: userId, comment: "comment to delete"});
 			await comment.save();
-			console.log("other user can't delete comment")
-			console.log('Post author', post.user);
-			console.log('Comment Author', comment.user);
-			console.log('Current User', user_id);
 			// Send a request to delete the comment
 			const response = await request(app)
 				.delete(`/comments/${comment._id}`)

--- a/api/spec/controllers/comments.spec.js
+++ b/api/spec/controllers/comments.spec.js
@@ -53,8 +53,7 @@ describe("/comments", () => {
         .post("/comments")
         .set("Authorization", `Bearer ${token}`)
         .send({post: post_id, user: user_id, comment: "testing comments", token: token });
-				expect(response.status).toEqual(201);
-
+			expect(response.status).toEqual(201);
 			});
 		
 			test("creates a new comment", async () => {
@@ -87,6 +86,16 @@ describe("/comments", () => {
 				// Assert comment is linked to user
 				expect(JSON.stringify(post_id)).toEqual(JSON.stringify(comments.post));
 			});
+			test("returns a new token", async () => {
+				let response = await request(app)
+					.post("/comments")
+					.set("Authorization", `Bearer ${token}`)
+					.send({post: post_id, user: user_id, comment: "hello world", token: token  })
+				let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
+				let originalPayload = JWT.decode(token, process.env.JWT_SECRET);
+				expect(newPayload.iat > originalPayload.iat).toEqual(true);
+			});
+
 		
  
   })

--- a/api/spec/controllers/comments.spec.js
+++ b/api/spec/controllers/comments.spec.js
@@ -98,7 +98,7 @@ describe("/comments", () => {
 	describe("POST, when token is missing", () => {
 		test("responds with a 401", async () => {
 			let response = await request(app)
-				.post("/posts")
+				.post("/comments")
 				.send({post: post_id, user: user_id, comment: "hello world"});
 			expect(response.status).toEqual(401);
 		});
@@ -168,7 +168,7 @@ describe("/comments", () => {
 			// Check the response status
 			expect(response.status).toEqual(200);
 			// Check if the comment is deleted from the database
-			const deleted_comment = await Comment.findById(comment._id_);
+			const deleted_comment = await Comment.findById(comment._id);
 			expect(deleted_comment).toBe(null);
 		});
 		test("returns a new token", async () => {

--- a/api/spec/controllers/comments.spec.js
+++ b/api/spec/controllers/comments.spec.js
@@ -184,7 +184,7 @@ describe("/comments", () => {
 		});
 	});
 	describe("DELETE, when token is missing", () => {
-		test("delete a comment by other user with 403 response", async () => {
+		test("other user can't delete comment, 403 response", async () => {
 			const userId = mongoose.Types.ObjectId();
 			const postId = mongoose.Types.ObjectId();
 			const comment = new Comment({post: postId, user: userId, comment: "comment to delete"});
@@ -198,16 +198,17 @@ describe("/comments", () => {
 			// Check if the comment is still in the database
 			expect(Comment.findById(comment._id_)).not.toBe(null);
 		});
-		test("returns a new token", async () => {
-			let comment = new Comment({post: post_id, user: user_id, comment: "comment to delete"});
+		test("a token is not returned", async () => {
+			const userId = mongoose.Types.ObjectId();
+			const postId = mongoose.Types.ObjectId();
+			const comment = new Comment({post: postId, user: userId, comment: "comment to delete"});
 			await comment.save();
+			// Send a request to delete the comment
 			const response = await request(app)
 				.delete(`/comments/${comment._id}`)
 				.set('Authorization', `Bearer ${token}`)
 				.send({ token: token });
-			let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
-			let originalPayload = JWT.decode(token, process.env.JWT_SECRET);
-			expect(newPayload.iat > originalPayload.iat).toEqual(true);
+				expect(response.body.token).toEqual(undefined);
 		});
 	});
 });

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -216,6 +216,19 @@ describe("/posts", () => {
       expect(response.body.token).toEqual(undefined);
     });
   });
-
-  
+  describe("DELETE, when token is present", () => {
+		test("delete a post with 200 response", async () => {
+      let post = new Post({ message: "to delete", user: user._id })
+      await post.save();
+      // Send a request to delete the posts
+			const response = await request(app)
+        .delete(`/posts/${post._id}`)
+        .set('Authorization', `Bearer ${token}`)
+      // Check the response status
+      expect(response.status).toEqual(200);
+      // Check if the post is deleted from the database
+      const deleted_post = await Post.findById(post._id);
+      expect(deleted_post).toBe(null);
+    })
+  });
 });

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -3,6 +3,7 @@ const request = require("supertest");
 require("../mongodb_helper");
 const Post = require("../../models/post");
 const User = require("../../models/user");
+const Comment = require('../../models/comment')
 const JWT = require("jsonwebtoken");
 const secret = process.env.JWT_SECRET;
 const TokenGenerator = require("../../lib/token_generator");
@@ -218,7 +219,7 @@ describe("/posts", () => {
     });
   });
   describe("DELETE, when token is present", () => {
-		test("delete a post with 200 response", async () => {
+		test("delete a post by post's author with 200 response", async () => {
       let post = new Post({ message: "to delete", user: user._id })
       await post.save();
       // Send a request to delete the post
@@ -230,6 +231,37 @@ describe("/posts", () => {
       // Check if the post is deleted from the database
       const deleted_post = await Post.findById(post._id);
       expect(deleted_post).toBe(null);
+    });
+    test("when post is deleted, associated comments are deleted as well", async () => {
+      // Create a post with comments
+      const post = new Post({ message: "Post with comments", user: user._id});
+      await post.save();
+      const userId = mongoose.Types.ObjectId();
+      const comment1 = new Comment({ post: post._id, user: userId, comment: "Comment 1" });
+      const comment2 = new Comment({ post: post._id, user: userId, comment: "Comment 2" });
+      await comment1.save();
+      await comment2.save();
+
+      // Send a request to delete the post
+      const response = await request(app)
+        .delete(`/posts/${post._id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      // Check the response status
+      expect(response.status).toEqual(200);
+
+      // Check if the post and its associated comments are deleted from the database
+      const deleted_post = await Post.findById(post._id);
+      expect(deleted_post).toBe(null);
+      // Check if associated comment1 doesn't exists
+      const deleted_comment1 = await Comment.findById(comment1._id);
+      expect(deleted_comment1).toBe(null);
+      // Check if associated comment2 doesn't exists
+      const deleted_comment2 = await Comment.findById(comment2._id);
+      expect(deleted_comment2).toBe(null);
+      // Check if any associated comments are deleted from the database
+      const comments = await Comment.find({ post: post._id });
+      expect(comments).toEqual([]);
     });
     test("returns a new token", async () => {
       let post = new Post({ message: "to delete", user: user._id })


### PR DESCRIPTION
Implemented and tested in backend:

- Owners of the comments can delete their own comments
- 
- Owners of the posts, associated to comments, can delete a comments
- 
- If other user tries to delete a comment, he recieve a response status 403 and error message Forbidden. You Are not allowed to delete this comment.
- 
- a new token generates after comment was deleted

Implemented and tested in backend:

- Owners of the posts can delete their own posts
- 
- Post deletes with associated comments
- 
- If other user tries to delete a post, he recieve a response status 403 and error message Forbidden. You Are not allowed to delete this post.
- 
- a new token generates after post was deleted

